### PR TITLE
Fixing Readme Syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Build macOS desktop apps using React Native and Cocoa.
 <View>
   <Button onClick={() => alert('clicked')} />
 </View>
+```
 
 ## Getting started
 


### PR DESCRIPTION
Just missing the closing code blocks tick marks.