### PR TITLE
Add Button state and allowsMixedState props

### DIFF
--- a/Examples/UIExplorer/js/ButtonExample.js
+++ b/Examples/UIExplorer/js/ButtonExample.js
@@ -60,14 +60,22 @@ exports.examples = [
     title: 'Switch',
     description: 'This style is a variant of NSToggleButton that has no border and is typically used to represent a checkbox.',
     render() {
-      return <Button type={'switch'} style={{width: 200}} title={'Single Checkbox'}/>;
+      return <View>
+        <Button type={'switch'} style={{width: 200}} title={'Single Checkbox'} state={0} />
+        <Button type={'switch'} style={{width: 200}} title={'Single Checkbox'} state={1} />
+        <Button type={'switch'} style={{width: 200}} title={'Single Checkbox'} allowsMixedState={true} state={-1} />
+      </View>
     }
   },
   {
     title: 'Radio',
     description: 'This style is similar to NSSwitchButton, but it is used to constrain a selection to a single element from several elements.',
     render() {
-      return <Button type={'radio'} style={{width: 200}} title={'Single Radio'}/>;
+      return <View>
+        <Button type={'radio'} style={{width: 200}} title={'Single Radio'} state={0} />
+        <Button type={'radio'} style={{width: 200}} title={'Single Radio'} state={1} />
+        <Button type={'radio'} style={{width: 200}} title={'Single Radio'} allowsMixedState={true} state={-1} />
+      </View>
     }
   },
   {

--- a/Libraries/Components/Button/Button.macos.js
+++ b/Libraries/Components/Button/Button.macos.js
@@ -77,6 +77,8 @@ const Button = React.createClass({
      *   {nativeEvent: { state }}.
      */
     onClick: PropTypes.func,
+    allowsMixedState: PropTypes.bool,
+    state: PropTypes.number
   },
 
   getDefaultProps: function(): DefaultProps {

--- a/React/Views/RCTButtonManager.m
+++ b/React/Views/RCTButtonManager.m
@@ -64,6 +64,8 @@ RCT_EXPORT_VIEW_PROPERTY(bezelStyle, NSBezelStyle)
 RCT_EXPORT_VIEW_PROPERTY(image, NSImage)
 RCT_EXPORT_VIEW_PROPERTY(alternateImage, NSImage)
 RCT_EXPORT_VIEW_PROPERTY(onClick, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(allowsMixedState, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(state, NSInteger)
 
 RCT_CUSTOM_VIEW_PROPERTY(type, NSButtonType, __unused NSButton)
 {


### PR DESCRIPTION
Adds [`state`][0] and [`allowsMixedState`][1] props to `Button` component.

This is my first PR for react-native-macos, so please let me know if I am missing something. :smile:

<img width="150" alt="screen shot 2016-08-24 at 7 29 47 pm" src="https://cloud.githubusercontent.com/assets/8601064/17957878/25c54ef2-6a31-11e6-8041-23a9f9f26227.png">

**Switch**:
```jsx
<Button type={'switch'} style={{width: 200}} title={'Single Checkbox'} state={0} />
<Button type={'switch'} style={{width: 200}} title={'Single Checkbox'} state={1} />
<Button type={'switch'} style={{width: 200}} title={'Single Checkbox'} allowsMixedState={true} state={-1} />
```

**Radio**:
```jsx
<Button type={'radio'} style={{width: 200}} title={'Single Radio'} state={0} />
<Button type={'radio'} style={{width: 200}} title={'Single Radio'} state={1} />
<Button type={'radio'} style={{width: 200}} title={'Single Radio'} allowsMixedState={true} state={-1} />
```

[0]: https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSButton_Class/#//apple_ref/occ/instp/NSButton/state
[1]: https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSButton_Class/#//apple_ref/occ/instp/NSButton/allowsMixedState