### PR TITLE
Fix text alignment crash in RCTTextField

### DIFF
--- a/Libraries/Text/RCTTextFieldManager.m
+++ b/Libraries/Text/RCTTextFieldManager.m
@@ -78,7 +78,7 @@ RCT_EXPORT_VIEW_PROPERTY(text, NSString)
 RCT_EXPORT_VIEW_PROPERTY(maxLength, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(focusRingType, NSFocusRingType)
 RCT_EXPORT_VIEW_PROPERTY(selectionColor, NSColor)
-RCT_REMAP_VIEW_PROPERTY(textAlign, textAlignment, NSTextAlignment)
+RCT_REMAP_VIEW_PROPERTY(textAlign, alignment, NSTextAlignment)
 RCT_REMAP_VIEW_PROPERTY(color, textColor, NSColor)
 RCT_CUSTOM_VIEW_PROPERTY(fontSize, NSNumber, RCTTextField)
 {


### PR DESCRIPTION
The name of the property was incorrect.