### PR TITLE
Clear touch handler states when gesture recognizer ended.

### DIFF
--- a/React/Base/RCTTouchHandler.m
+++ b/React/Base/RCTTouchHandler.m
@@ -343,6 +343,9 @@ typedef NS_ENUM(NSInteger, RCTTouchEventType) {
 - (void)reset
 {
   _dispatchedInitialTouches = NO;
+  [_touchViews removeAllObjects];
+  [_nativeTouches removeAllObjects];
+  [_reactTouches removeAllObjects];
 }
 
 - (void)cancel


### PR DESCRIPTION
In RCTTouchHandler, touch states are removed in `-[RCTTouchHandler _recordRemovedTouches:]`, which is called in `-[RCTTouchHandler mouseUp:]`. The problem is `-[RCTTouchHandler mouseUp:]` is not guaranteed to be called, and when it's not, the touch states would be wrong.

So, correct me if I was wrong, I think touch states need to be cleared some where, and I think `-[NSGestureRecognizer reset]` might be the right place.