### PR TITLE
Fix  #85 - callback associated with button in Alert.alert not working

### DIFF
--- a/React/Modules/RCTAlertManager.m
+++ b/React/Modules/RCTAlertManager.m
@@ -99,7 +99,10 @@ RCT_EXPORT_METHOD(alertWithArgs:(NSDictionary *)args
   [_alertCallbacks addObject:callback ?: ^(__unused id unused) {}];
   [_alertButtonKeys addObject:buttonKeys];
 
-  [alertView runModal];
+  NSInteger buttonPosition = [alertView runModal];
+  NSString *buttonKey = [buttonKeys objectAtIndex: buttonPosition - NSAlertFirstButtonReturn];
+  
+  callback(@[buttonKey]);
 }
 
 @end


### PR DESCRIPTION
Hi, i try to fix alerts callback and it's work now, but i don't understand some variables in RCTAlertManager.m:

```
NSMutableArray<NSAlert *> *_alerts;
NSMutableArray<RCTResponseSenderBlock> *_alertCallbacks;
NSMutableArray<NSArray<NSString *> *> *_alertButtonKeys;
```
So if you can explain for what it, i'll complete it =)

Thanks
