### PR TITLE
Allow react-native-macos package.json shims

### DIFF
--- a/packager/react-packager/src/node-haste/Package.js
+++ b/packager/react-packager/src/node-haste/Package.js
@@ -108,14 +108,24 @@ class Package {
 }
 
 function getReplacements(pkg) {
+  let rnm = pkg['react-native-macos'];
   let rn = pkg['react-native'];
   let browser = pkg.browser;
-  if (rn == null) {
+  
+  if (rnm == null && rn == null) {
     return browser;
   }
-
-  if (browser == null) {
+  
+  if (rnm == null && browser == null) {
     return rn;
+  }
+
+  if (rn == null && browser == null) {
+    return rnm;
+  }
+
+  if (typeof rnm === 'string') {
+    rnm = { [pkg.main]: rnm };
   }
 
   if (typeof rn === 'string') {
@@ -127,8 +137,9 @@ function getReplacements(pkg) {
   }
 
   // merge with "browser" as default,
-  // "react-native" as override
-  return { ...browser, ...rn };
+  // "react-native" as override 1
+  // "react-native-macos" as override 2
+  return { ...browser, ...rn, ...rnm };
 }
 
 module.exports = Package;


### PR DESCRIPTION
This commit makes it possible to share code more broadly between react native platforms. For example, take the following package.json field:

package.json
```json
"react-native-macos": { "react-native": "react-native-macos" }
```
With this set our components can import from react-native rather than react-native-macos, allowing code sharing between react native platforms more easily.

Having the ability to use the same imports across platforms is incredibly important. Using the `browser` or `react-native` fields of package.json is the accepted way by the community to shim global requires (it's the only way that the React packager accepts shims). The React Native Web project uses a webpack alias to make it possible to use React Native code to target the web without modification.

The new `react-native-macos` field in package.json that functions the same way as `react-native` to shim one-level deep requires/imports. See https://github.com/facebook/react-native/issues/5917 for details of `browser` and `react-native` fields.

I've tested this locally myself and it works fine. I've tried to keep the same rules in this commit, simply adding react native macos as the highest precedence for shimming.