### PR TITLE
Fix onSubmitEditing for text fields

### DIFF
--- a/Libraries/Text/RCTTextField.h
+++ b/Libraries/Text/RCTTextField.h
@@ -16,7 +16,7 @@
 @interface TextFieldCellWithPaddings : NSTextFieldCell
 @end
 
-@interface RCTTextField : NSTextField <NSTextFieldDelegate>
+@interface RCTTextField : NSTextField <NSTextFieldDelegate, NSControlTextEditingDelegate>
 
 @property (nonatomic, assign) BOOL caretHidden;
 @property (nonatomic, assign) BOOL autoCorrect;
@@ -35,5 +35,6 @@
 //- (void)textFieldDidChange:(NSNotification *)aNotification;
 - (void)sendKeyValueForString:(NSString *)string;
 - (BOOL)textFieldShouldEndEditing:(RCTTextField *)textField;
+- (void)textFieldSubmitEditingWithString:(NSString *)key;
 
 @end

--- a/Libraries/Text/RCTTextField.m
+++ b/Libraries/Text/RCTTextField.m
@@ -185,13 +185,13 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
                                       key:nil
                                eventCount:_nativeEventCount];
 }
-- (void)textFieldSubmitEditing
+- (void)textFieldSubmitEditingWithString:(NSString *)key
 {
   _submitted = YES;
   [_eventDispatcher sendTextEventWithType:RCTTextEventTypeSubmit
                                  reactTag:self.reactTag
                                      text:[self stringValue]
-                                      key:nil
+                                      key:key
                                eventCount:_nativeEventCount];
 }
 

--- a/Libraries/Text/RCTTextFieldManager.m
+++ b/Libraries/Text/RCTTextFieldManager.m
@@ -40,6 +40,21 @@ RCT_EXPORT_MODULE()
   return textField;
 }
 
+- (BOOL)control:(NSControl *)control textView:(NSTextView * __unused)textView doCommandBySelector:(SEL)commandSelector {
+  if (![control isKindOfClass:[RCTTextField class]]) {
+    return YES;
+  }
+  
+  RCTTextField *textField = (RCTTextField*)control;
+  
+  if (commandSelector == @selector(insertNewline:)) {
+    [textField textFieldSubmitEditingWithString:@"\n"];
+    return YES;
+  }
+  
+  return NO;
+}
+
 - (BOOL)textField:(RCTTextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string
 {
   // Only allow single keypresses for onKeyPress, pasted text will not be sent.
@@ -52,6 +67,7 @@ RCT_EXPORT_MODULE()
   if (textField.maxLength == nil || [string isEqualToString:@"\n"]) {  // Make sure forms can be submitted via return
     return YES;
   }
+  
   return YES;
 }
 


### PR DESCRIPTION
This pull request adds support for `onSubmitEditing` on `<TextFields>`s.

The function `_renderIOS` was copied as `_renderMacOS` with the `onSubmitEditing` hook added, as iOS doesn't really have support for it and it didn't seem sensible to have them share that function any longer.

Looking forward to feedback.