### PR TITLE
Fix scrollTo for ScrollView

### DIFF
--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -440,7 +440,7 @@ const ScrollResponderMixin = {
 
     UIManager.dispatchViewManagerCommand(
       nullthrows(this.scrollResponderGetScrollableNode()),
-      UIManager.RCTScrollView.Commands.scrollTo,
+      commandID,
       [x || 0, y || 0, animated !== false]
     );
   },

--- a/Libraries/ReactNative/UIManager.js
+++ b/Libraries/ReactNative/UIManager.js
@@ -44,7 +44,7 @@ UIManager.takeSnapshot = function() {
  * only needed for iOS, which puts the constants in the ViewManager
  * namespace instead of UIManager, unlike Android.
  */
-if (Platform.OS === 'ios') {
+if (Platform.OS === 'ios' || Platform.OS === 'macos') {
   Object.keys(UIManager).forEach(viewName => {
     const viewConfig = UIManager[viewName];
     if (viewConfig.Manager) {


### PR DESCRIPTION
Fix `scrollTo` in `ScrollView`. 

To support this change I had to populate the `Commands` property 
e.g. `UIManager.RCTNativeScrollView.Commands.scrollTo;` via this commit https://github.com/ptmt/react-native-macos/commit/3e2557061a0beff3bdf27d7f082f2676cfa132f2.