### PR TITLE
Add missing import for #208

### DIFF
--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -12,6 +12,7 @@
 'use strict';
 
 const Dimensions = require('Dimensions');
+const Platform = require('Platform');
 const FrameRateLogger = require('FrameRateLogger');
 const Keyboard = require('Keyboard');
 const ReactNative = require('ReactNative');


### PR DESCRIPTION
I retested #208 with the latest (0.18.0) version, `Platform` must be imported, otherwise results in a crash when `scrollTo` is used. 