### PR TITLE
Fix bordered and bezeled property not being forwarded

### DIFF
--- a/Libraries/Text/RCTTextFieldManager.m
+++ b/Libraries/Text/RCTTextFieldManager.m
@@ -47,6 +47,8 @@ RCT_EXPORT_MODULE()
     return textField;
 }
 
+RCT_EXPORT_VIEW_PROPERTY(bezeled, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(bordered, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(caretHidden, BOOL)
 RCT_REMAP_VIEW_PROPERTY(editable, enabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(placeholder, NSString)


### PR DESCRIPTION
RCTTextInputManager.m seemed to be missing the property export for bezeled and bordered. This add that back.
```
RCT_EXPORT_VIEW_PROPERTY(bezeled, BOOL)
RCT_EXPORT_VIEW_PROPERTY(bordered, BOOL)
```

TextInput can now configure whether the border/bezel is displayed.
```
<TextInput
    bordered={false}
    bezeled={false}
/>
```