### PR TITLE
Fix placeholder not showing if placeholderTextColor is not set

### DIFF
--- a/Libraries/Text/RCTTextField.m
+++ b/Libraries/Text/RCTTextField.m
@@ -132,6 +132,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
 - (void)updatePlaceholder
 {
+  [self setPlaceholderString:_placeholderString];
   if (_placeholderTextColor && _placeholderString) {
     NSAttributedString *attrString = [[NSAttributedString alloc]
                                       initWithString:_placeholderString attributes: @{


### PR DESCRIPTION
TextInput placeholderText should still display even if no placeholderTextColor is set. This aligns with how NSTextField behaves.

```
<TextInput
    placeholder="search"
/>
```