### PR TITLE
fix: RCTRedBox tweaks

### DIFF
--- a/React/Modules/RCTRedBox.m
+++ b/React/Modules/RCTRedBox.m
@@ -22,17 +22,33 @@
 
 #if RCT_DEBUG
 
+const CGFloat buttonHeight = 50;
+const CGFloat buttonMargin = 10;
+
 @interface ErrorNSTableView : NSTableView;
 @end
 
 @implementation ErrorNSTableView
+
 - (BOOL)isFlipped
 {
   return YES;
 }
+
+- (void)setFrameSize:(NSSize)newSize
+{
+  // Add padding to the bottom of the scroll view.
+  newSize.height += buttonHeight + (buttonMargin * 2);
+  [super setFrameSize:newSize];
+}
+
 @end
 
 @class RCTRedBoxWindow;
+
+@interface RCTRedBoxButton : NSButton
+- (void)setBackgroundColor:(NSColor *)backgroundColor;
+@end
 
 @protocol RCTRedBoxWindowActionDelegate <NSObject>
 
@@ -49,7 +65,7 @@
 
 @implementation RCTRedBoxWindow
 {
-  ErrorNSTableView *_stackTraceTableView;
+  NSTableView *_stackTraceTableView;
   NSString *_lastErrorMessage;
   NSArray<RCTJSStackFrame *> *_lastStackTrace;
   NSTextField * _temporaryHeader;
@@ -57,77 +73,69 @@
 
 - (instancetype)initWithContentRect:(NSRect)frame
 {
-
-  if ((self = [super initWithContentRect:frame
-                               styleMask:NSWindowStyleMaskClosable | NSResizableWindowMask | NSWindowStyleMaskFullSizeContentView
-                                 backing:NSBackingStoreBuffered defer:NO])) {
-
+  self = [super initWithContentRect:frame
+                          styleMask:NSWindowStyleMaskClosable | NSWindowStyleMaskTitled
+                            backing:NSBackingStoreBuffered defer:NO];
+  if (self) {
+    NSColor *backgroundColor = [NSColor colorWithRed:0.1 green:0.1 blue:0.1 alpha:1];
     RCTView *rootView = [[RCTView alloc] initWithFrame:frame];
-
-    [rootView setBackgroundColor:[NSColor colorWithRed:0.8 green:0 blue:0 alpha:1]];
-    rootView.autoresizesSubviews = true;
-
-        const CGFloat buttonHeight = 60;
-
-    CGRect detailsFrame = self.frame;
-    detailsFrame.size.height -= buttonHeight;
-
-    _stackTraceTableView = [[ErrorNSTableView alloc] initWithFrame:detailsFrame];
-    _stackTraceTableView.delegate = self;
-    _stackTraceTableView.dataSource = self;
-    NSTableColumn *column = [[NSTableColumn alloc] initWithIdentifier:@"column"];
-    column.width = frame.size.width;
-    [_stackTraceTableView addTableColumn:column];
-
-    CALayer *viewLayer = [CALayer layer];
-    [_stackTraceTableView setBackgroundColor:[NSColor colorWithRed:0.8 green:0 blue:0 alpha:1]];
-    [_stackTraceTableView setWantsLayer:YES];
-    [_stackTraceTableView setLayer:viewLayer];
-
-    _temporaryHeader = [[NSTextField alloc] initWithFrame: CGRectMake(20, 20, self.frame.size.width - 100, self.frame.size.height - buttonHeight)];
-    _temporaryHeader.textColor = [NSColor whiteColor];
-    [_temporaryHeader setBackgroundColor:[NSColor colorWithRed:0.8 green:0 blue:0 alpha:1]];
-    //_temporaryHeader.alignment = NSTextAlignmentCenter;
-    _temporaryHeader.font = [NSFont boldSystemFontOfSize:14];
-    _temporaryHeader.lineBreakMode = NSLineBreakByWordWrapping;
-    _temporaryHeader.bordered = NO;
-    _temporaryHeader.selectable = YES;
-    _temporaryHeader.editable = false;
-    [rootView addSubview:_temporaryHeader];
-
-
-    NSButton *dismissButton = [[NSButton alloc] init];
-    [dismissButton setBezelStyle:NSRecessedBezelStyle];
-    dismissButton.autoresizingMask = NSViewMaxXMargin | NSViewMaxYMargin;
+    rootView.backgroundColor = backgroundColor;
+    
+    NSColor *buttonColor = [NSColor colorWithRed:0.8 green:0.15 blue:0.15 alpha:1];
+    CGSize  buttonSize   = {(frame.size.width / 3) - (buttonMargin * 2), buttonHeight};
+    CGPoint buttonOrigin = {buttonMargin, frame.size.height - buttonHeight - buttonMargin};
+    NSDictionary *buttonAttributes = @{
+      NSFontAttributeName: [NSFont systemFontOfSize:20],
+      NSForegroundColorAttributeName: [NSColor whiteColor],
+      NSBackgroundColorAttributeName: [NSColor clearColor],
+    };
+    
+    RCTRedBoxButton *dismissButton = [RCTRedBoxButton new];
+    dismissButton.frame = (CGRect){buttonOrigin, buttonSize};
+    dismissButton.backgroundColor = buttonColor;
     dismissButton.accessibilityIdentifier = @"redbox-dismiss";
-    dismissButton.font = [NSFont systemFontOfSize:20];
-    [dismissButton setTitle:@"Dismiss (ESC)"];
-    [dismissButton setTarget:self];
-    [dismissButton setAction:@selector(dismiss)];
-
-    NSButton *reloadButton = [[NSButton alloc] init];
-    [reloadButton setBezelStyle:NSRecessedBezelStyle];
-    reloadButton.autoresizingMask = NSViewMaxXMargin | NSViewMaxYMargin;
+    dismissButton.attributedTitle = [[NSAttributedString alloc] initWithString:@"Dismiss (ESC)" attributes:buttonAttributes];
+    dismissButton.target = self;
+    dismissButton.action = @selector(dismiss);
+    
+    buttonOrigin.x += frame.size.width / 3;
+    RCTRedBoxButton *reloadButton = [RCTRedBoxButton new];
+    reloadButton.frame = (CGRect){buttonOrigin, buttonSize};
+    reloadButton.backgroundColor = buttonColor;
     reloadButton.accessibilityIdentifier = @"redbox-reload";
-    reloadButton.font = [NSFont systemFontOfSize:20];
-    [reloadButton setTitle:@"Reload JS (\u2318R)"];
-    [reloadButton setTarget:self];
-    [reloadButton setAction:@selector(reload)];
-
-    NSButton *copyButton = [[NSButton alloc] init];
-    [copyButton setBezelStyle:NSRecessedBezelStyle];
-    copyButton.autoresizingMask = NSViewMaxXMargin | NSViewMaxYMargin;
+    reloadButton.attributedTitle = [[NSAttributedString alloc] initWithString:@"Reload JS (\u2318R)" attributes:buttonAttributes];
+    reloadButton.target = self;
+    reloadButton.action = @selector(reload);
+    
+    buttonOrigin.x += frame.size.width / 3;
+    RCTRedBoxButton *copyButton = [RCTRedBoxButton new];
+    copyButton.frame = (CGRect){buttonOrigin, buttonSize};
+    copyButton.backgroundColor = buttonColor;
     copyButton.accessibilityIdentifier = @"redbox-copy";
-    copyButton.font = [NSFont systemFontOfSize:20];
-    [copyButton setTitle:@"Copy (\u2325\u2318C)"];
-    [copyButton setTarget:self];
-    [copyButton setAction:@selector(copyStack)];
-
-    CGFloat buttonWidthWithMargin = self.frame.size.width / 3;
-    CGFloat buttonWidth = buttonWidthWithMargin - 20;
-    dismissButton.frame = CGRectMake(10, self.frame.size.height - buttonHeight - 10, buttonWidth, buttonHeight);
-    reloadButton.frame = CGRectMake(self.frame.size.width / 3 + 10, self.frame.size.height - buttonHeight - 10, buttonWidth, buttonHeight);
-    copyButton.frame = CGRectMake(2 * self.frame.size.width / 3 + 10, self.frame.size.height - buttonHeight - 10, buttonWidth, buttonHeight);
+    copyButton.attributedTitle = [[NSAttributedString alloc] initWithString:@"Copy (\u2325\u2318C)" attributes:buttonAttributes];
+    copyButton.target = self;
+    copyButton.action = @selector(copyStack);
+    
+    _stackTraceTableView = [[ErrorNSTableView alloc] initWithFrame:CGRectZero];
+    _stackTraceTableView.backgroundColor = [NSColor clearColor];
+    _stackTraceTableView.headerView = nil;
+    _stackTraceTableView.dataSource = self;
+    _stackTraceTableView.delegate = self;
+    
+    NSTableColumn *column = [[NSTableColumn alloc] initWithIdentifier:@"column"];
+    [_stackTraceTableView addTableColumn:column];
+    
+    CGFloat scrollPadding = 20;
+    frame = NSInsetRect(frame, scrollPadding, scrollPadding);
+    frame.size.width += scrollPadding;
+    frame.size.height += scrollPadding;
+    
+    NSScrollView *scrollView = [[NSScrollView alloc] initWithFrame:frame];
+    scrollView.backgroundColor = [NSColor clearColor];
+    scrollView.documentView = _stackTraceTableView;
+    scrollView.contentView.backgroundColor = backgroundColor;
+    
+    [rootView addSubview:scrollView];
     [rootView addSubview:dismissButton];
     [rootView addSubview:reloadButton];
     [rootView addSubview:copyButton];
@@ -145,42 +153,18 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (void)redBoxWindow:(__unused RCTRedBoxWindow *)redBoxWindow openStackFrameInEditor:(RCTJSStackFrame *)stackFrame
-{
-  if (![_bridge.bundleURL.scheme hasPrefix:@"http"]) {
-    RCTLogWarn(@"Cannot open stack frame in editor because you're not connected to the packager.");
-    return;
-  }
-  NSData *stackFrameJSON = [RCTJSONStringify(stackFrame, NULL) dataUsingEncoding:NSUTF8StringEncoding];
-  NSString *postLength = [NSString stringWithFormat:@"%tu", stackFrameJSON.length];
-  NSMutableURLRequest *request = [NSMutableURLRequest new];
-  request.URL = [RCTConvert NSURL:@"http://localhost:8081/open-stack-frame"];
-  request.HTTPMethod = @"POST";
-  request.HTTPBody = stackFrameJSON;
-  [request setValue:postLength forHTTPHeaderField:@"Content-Length"];
-  [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
-
-  [[[NSURLSession sharedSession] dataTaskWithRequest:request] resume];
-}
-
 - (void)showErrorMessage:(NSString *)message withStack:(NSArray<RCTJSStackFrame *> *)stack isUpdate:(BOOL)isUpdate
 {
-  if ((!self.isVisible && isUpdate) || (self.isVisible && [_lastErrorMessage isEqualToString:message])) {
+  if (!self.isVisible || isUpdate) {
     _lastStackTrace = stack;
     _lastErrorMessage = [message substringToIndex:MIN((NSUInteger)10000, message.length)];
-    NSMutableArray *result = [NSMutableArray arrayWithCapacity:stack.count];
-    [stack enumerateObjectsUsingBlock:^(RCTJSStackFrame* stackFrame, __unused NSUInteger idx, __unused BOOL *stop) {
-      NSString *lineInfo = [self formatFrameSource:stackFrame];
 
-      NSString *methodName = [@"\t in " stringByAppendingString:stackFrame.methodName];
-
-      [result addObject:[methodName stringByAppendingFormat:@"(at %@)", lineInfo]];
-    }];
-
-
-    [_temporaryHeader setStringValue:[message stringByAppendingString:[result componentsJoinedByString:@"\n"]]];
     [_stackTraceTableView reloadData];
-
+    [_stackTraceTableView sizeToFit];
+    
+    NSApplication *app = [NSApplication sharedApplication];
+    [app setActivationPolicy:NSApplicationActivationPolicyRegular];
+    
     [self makeKeyAndOrderFront:nil];
     [self becomeFirstResponder];
   }
@@ -205,17 +189,17 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
 - (void)copyStack
 {
-    NSMutableString *fullStackTrace;
+  NSMutableString *fullStackTrace;
 
-    if (_lastErrorMessage != nil) {
-        fullStackTrace = [_lastErrorMessage mutableCopy];
-        [fullStackTrace appendString:@"\n\n"];
-    }
-    else {
-        fullStackTrace = [NSMutableString string];
-    }
+  if (_lastErrorMessage != nil) {
+    fullStackTrace = [_lastErrorMessage mutableCopy];
+    [fullStackTrace appendString:@"\n\n"];
+  }
+  else {
+    fullStackTrace = [NSMutableString string];
+  }
 
-for (RCTJSStackFrame *stackFrame in _lastStackTrace) {
+  for (RCTJSStackFrame *stackFrame in _lastStackTrace) {
     [fullStackTrace appendString:[NSString stringWithFormat:@"%@\n", stackFrame.methodName]];
     if (stackFrame.file) {
       [fullStackTrace appendFormat:@"    %@\n", [self formatFrameSource:stackFrame]];
@@ -228,43 +212,40 @@ for (RCTJSStackFrame *stackFrame in _lastStackTrace) {
 
 - (NSString *)formatFrameSource:(RCTJSStackFrame *)stackFrame
 {
-    NSString *fileName = RCTNilIfNull(stackFrame.file) ? [stackFrame.file lastPathComponent] : @"<unknown file>";
-    NSString *lineInfo = [NSString stringWithFormat:@"%@:%lld",
-                          fileName,
-                          (long long)stackFrame.lineNumber];
+  NSString *fileName = RCTNilIfNull(stackFrame.file) ? [stackFrame.file lastPathComponent] : @"<unknown file>";
+  NSString *lineInfo = [NSString stringWithFormat:@"%@:%lld",
+                        fileName,
+                        (long long)stackFrame.lineNumber];
 
-    if (stackFrame.column != 0) {
-        lineInfo = [lineInfo stringByAppendingFormat:@":%lld", (long long)stackFrame.column];
-    }
-    return lineInfo;
+  if (stackFrame.column != 0) {
+    lineInfo = [lineInfo stringByAppendingFormat:@":%lld", (long long)stackFrame.column];
+  }
+  return lineInfo;
 }
 
 #pragma mark - TableView
 
-- (NSView *)tableView:(NSTableView *)tableView viewForTableColumn:(__unused NSTableColumn *)tableColumn row:(NSInteger)row {
-
-  NSLog(@"RCTRedBox: viewForTableColumn %ld", (long)row);
-
+- (NSView *)tableView:(NSTableView *)tableView viewForTableColumn:(__unused NSTableColumn *)tableColumn row:(NSInteger)row
+{
   if (row == 0) {
     NSTextField *cell = [tableView makeViewWithIdentifier:@"msg-cell" owner:self];
     return [self reuseCell:cell forErrorMessage:_lastErrorMessage];
   }
   NSTextField *cell = [tableView makeViewWithIdentifier:@"cell" owner:self];
-  //NSUInteger index = indexPath.row;
-  NSDictionary *stackFrame = _lastStackTrace[row];
+  NSDictionary *stackFrame = [_lastStackTrace[row - 1] toDictionary];
   return [self reuseCell:cell forStackFrame:stackFrame];
 }
 
 - (NSTextField *)reuseCell:(NSTextField *)cell forErrorMessage:(NSString *)message
 {
   if (!cell) {
-    cell = [[NSTextField alloc] initWithFrame:self.frame];
-    cell.accessibilityIdentifier = @"redbox-error";
-    cell.textColor = [NSColor blackColor];
-    cell.alignment = NSTextAlignmentCenter;
+    cell = [[NSTextField alloc] initWithFrame:self.contentView.frame];
+    cell.accessibilityIdentifier = @"redbox-error-message";
+    cell.textColor = [NSColor whiteColor];
     cell.font = [NSFont boldSystemFontOfSize:16];
     cell.lineBreakMode = NSLineBreakByWordWrapping;
-    cell.backgroundColor = [NSColor colorWithRed:0.8 green:0 blue:0 alpha:1];
+    cell.backgroundColor = [NSColor clearColor];
+    cell.bordered = false;
     cell.editable = false;
   }
   [cell setStringValue:message];
@@ -274,11 +255,13 @@ for (RCTJSStackFrame *stackFrame in _lastStackTrace) {
 - (NSTextField *)reuseCell:(NSTextField *)cell forStackFrame:(NSDictionary *)stackFrame
 {
   if (!cell) {
-    cell = [[NSTextField alloc] initWithFrame:self.frame];
+    cell = [[NSTextField alloc] initWithFrame:self.contentView.frame];
+    cell.accessibilityIdentifier = @"redbox-stack-frame";
     cell.textColor = [NSColor whiteColor];
-    cell.font = [NSFont boldSystemFontOfSize:11];
-    cell.lineBreakMode = NSLineBreakByWordWrapping;
+    cell.font = [NSFont fontWithName:@"Menlo-Regular" size:16];
+    cell.lineBreakMode = NSLineBreakByCharWrapping;
     cell.backgroundColor = [NSColor clearColor];
+    cell.bordered = false;
     cell.editable = false;
   }
 
@@ -311,24 +294,25 @@ for (RCTJSStackFrame *stackFrame in _lastStackTrace) {
 
 - (NSInteger)numberOfRowsInTableView:(__unused NSTableView *)tableView
 {
-  NSInteger count = (_lastStackTrace ? _lastStackTrace.count : 1);
-  return _lastStackTrace ? _lastStackTrace.count : 1;
+  return 1 + _lastStackTrace.count;
 }
 
--(NSInteger)numberOfColumns:(__unused NSTableView *)tableView {
+-(NSInteger)numberOfColumns:(__unused NSTableView *)tableView
+{
   return 1;
 }
 
+- (BOOL)tableView:(__unused NSTableView *)tableView shouldSelectRow:(NSInteger)row
+{
+  return row > 0;
+}
 
-//- (void)tableView:(NSTableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
-//{
-//  if (indexPath.section == 1) {
-//    NSUInteger row = indexPath.row;
-//    NSDictionary *stackFrame = _lastStackTrace[row];
-//    [self openStackFrameInEditor:stackFrame];
-//  }
-//  [tableView deselectRowAtIndexPath:indexPath animated:YES];
-//}
+- (void)tableViewSelectionDidChange:(__unused NSNotification *)notification
+{
+  NSInteger row = _stackTraceTableView.selectedRow;
+  [_actionDelegate redBoxWindow:self openStackFrameInEditor:_lastStackTrace[row - 1]];
+  [_stackTraceTableView deselectRow:row];
+}
 
 #pragma mark - Key commands
 
@@ -466,8 +450,12 @@ RCT_EXPORT_MODULE()
         [self->_bridge.eventDispatcher sendDeviceEventWithName:@"collectRedBoxExtraData" body:nil];
 
         if (!self->_window) {
-          self->_window = [[RCTRedBoxWindow alloc] initWithContentRect:[[NSApplication sharedApplication] mainWindow].frame];
-            self->_window.actionDelegate = self;
+          NSSize screenSize = NSScreen.mainScreen.frame.size;
+          NSRect contentRect = (CGRect){NSZeroPoint, {screenSize.width / 3, screenSize.height / 1.5}};
+
+          self->_window = [[RCTRedBoxWindow alloc] initWithContentRect:contentRect];
+          self->_window.actionDelegate = self;
+          [self->_window center];
         }
 
         RCTErrorInfo *errorInfo = [[RCTErrorInfo alloc] initWithErrorMessage:message
@@ -489,7 +477,7 @@ RCT_EXPORT_MODULE()
     });
 }
 
-RCT_EXPORT_METHOD(setExtraData:(NSDictionary *)extraData forIdentifier:(NSString *)identifier) {
+RCT_EXPORT_METHOD(setExtraData:(NSDictionary *)extraData forIdentifier:(__unused NSString *)identifier) {
     // [_extraDataViewController addExtraData:extraData forIdentifier:identifier];
     NSLog(@"_extraDataViewController is not yet implemented %@", extraData);
 }
@@ -517,7 +505,7 @@ RCT_EXPORT_METHOD(dismiss)
     NSData *stackFrameJSON = [RCTJSONStringify([stackFrame toDictionary], NULL) dataUsingEncoding:NSUTF8StringEncoding];
     NSString *postLength = [NSString stringWithFormat:@"%tu", stackFrameJSON.length];
     NSMutableURLRequest *request = [NSMutableURLRequest new];
-    request.URL = [NSURL URLWithString:@"/open-stack-frame" relativeToURL:bundleURL];
+    request.URL = [RCTConvert NSURL:@"http://localhost:8081/open-stack-frame"];
     request.HTTPMethod = @"POST";
     request.HTTPBody = stackFrameJSON;
     [request setValue:postLength forHTTPHeaderField:@"Content-Length"];
@@ -540,6 +528,51 @@ RCT_EXPORT_METHOD(dismiss)
         [_bridge reload];
     }
     [self dismiss];
+}
+
+@end
+
+@interface RCTRedBoxButtonCell : NSButtonCell
+@end
+
+@implementation RCTRedBoxButton
+
++ (Class)cellClass {
+  return [RCTRedBoxButtonCell class];
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        self.bezelStyle = NSBezelStyleRecessed;
+    }
+    return self;
+}
+
+- (void)setBackgroundColor:(NSColor *)backgroundColor
+{
+  self.wantsLayer = true;
+  self.layer.backgroundColor = backgroundColor.CGColor;
+}
+
+@end
+
+@implementation RCTRedBoxButtonCell
+
+- (NSRect)titleRectForBounds:(NSRect)rect
+{
+    NSRect titleFrame = [super titleRectForBounds:rect];
+    NSSize titleSize = self.attributedTitle.size;
+    titleFrame.origin.x = (rect.size.width - titleSize.width) / 2;
+    titleFrame.origin.y = (rect.size.height - titleSize.height) / 2;
+    return titleFrame;
+}
+
+- (void)drawWithFrame:(NSRect)cellFrame inView:(__unused NSView *)controlView
+{
+    NSRect titleRect = [self titleRectForBounds:cellFrame];
+    [self.attributedTitle drawInRect:titleRect];
 }
 
 @end


### PR DESCRIPTION
- add NSScrollView for scrolling the NSTableView
- fix clicking a stack frame to launch an editor
- center the RCTRedBoxWindow in the middle of the screen
- use a dark color theme (to save my eyeballs)
- make the buttons a little better looking
- change font family for stack frames
- clean up the code some

<img src="https://user-images.githubusercontent.com/1925840/51716303-51769b00-200a-11e9-9823-2bd0518bdc54.gif" width="400" />

I would love to replace the 2nd stack trace (provided by `react-native`) with 1st one (provided by `react`), but I haven't looked into it yet.