### PR TITLE
More RCTRedBox improvements

### DIFF
--- a/Libraries/BatchedBridge/NativeModules.js
+++ b/Libraries/BatchedBridge/NativeModules.js
@@ -12,6 +12,7 @@
 'use strict';
 
 const BatchedBridge = require('BatchedBridge');
+const ExceptionsManager = require('ExceptionsManager');
 
 const invariant = require('fbjs/lib/invariant');
 
@@ -104,7 +105,11 @@ function genMethod(moduleID: number, methodID: number, type: MethodType) {
       const onFail = hasErrorCallback ? secondLastArg : null;
       const callbackCount = hasSuccessCallback + hasErrorCallback;
       args = args.slice(0, args.length - callbackCount);
-      BatchedBridge.enqueueNativeCall(moduleID, methodID, args, onFail, onSuccess);
+      try {
+        BatchedBridge.enqueueNativeCall(moduleID, methodID, args, onFail, onSuccess);
+      } catch(e) {
+        ExceptionsManager.handleException(e, true);
+      }
     };
   }
   fn.type = type;

--- a/React/Base/RCTLog.mm
+++ b/React/Base/RCTLog.mm
@@ -242,8 +242,7 @@ void _RCTLogNativeInternal(RCTLogLevel level, const char *fileName, int lineNumb
         }
 
         if (idx == 1 && fileName) {
-          NSString *file = [@(fileName) componentsSeparatedByString:@"/"].lastObject;
-          [stack addObject:@{@"methodName": methodName, @"file": file, @"lineNumber": @(lineNumber)}];
+          [stack addObject:@{@"methodName": methodName, @"file": @(fileName), @"lineNumber": @(lineNumber)}];
         } else {
           [stack addObject:@{@"methodName": methodName}];
         }

--- a/React/Base/RCTLog.mm
+++ b/React/Base/RCTLog.mm
@@ -252,7 +252,7 @@ void _RCTLogNativeInternal(RCTLogLevel level, const char *fileName, int lineNumb
       dispatch_async(dispatch_get_main_queue(), ^{
         // red box is thread safe, but by deferring to main queue we avoid a startup
         // race condition that causes the module to be accessed before it has loaded
-       // [[RCTBridge currentBridge].redBox showErrorMessage:message withStack:stack];
+        [[RCTBridge currentBridge].redBox showErrorMessage:message withStack:stack];
       });
     }
 

--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -420,7 +420,7 @@ struct RCTInstanceCallback : public InstanceCallback {
   } else {
     [RCTJavaScriptLoader loadBundleAtURL:self.bundleURL onProgress:onProgress onComplete:^(NSError *error, RCTSource *source) {
       if (error) {
-        RCTLogError(@"Failed to load bundle(%@) with error:(%@ %@)", self.bundleURL, error.localizedDescription, error.localizedFailureReason);
+        RCTLogError(@"Failed to load bundle: %@\n\n%@ %@", self.bundleURL, error.localizedDescription, error.localizedFailureReason ?: @"");
         return;
       }
       onSourceLoad(error, source);

--- a/React/Modules/RCTRedBox.m
+++ b/React/Modules/RCTRedBox.m
@@ -323,8 +323,10 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 - (void)tableViewSelectionDidChange:(__unused NSNotification *)notification
 {
   NSInteger row = _stackTraceTableView.selectedRow;
-  [_actionDelegate redBoxWindow:self openStackFrameInEditor:_lastStackTrace[row - 1]];
-  [_stackTraceTableView deselectRow:row];
+  if (row > 0) {
+    [_stackTraceTableView deselectRow:row];
+    [_actionDelegate redBoxWindow:self openStackFrameInEditor:_lastStackTrace[row - 1]];
+  }
 }
 
 #pragma mark - Key commands


### PR DESCRIPTION
- fix: RCTRedBox#copyStack
  - use NSPasteboard correctly
  - avoid truncating the error message too early
  - avoid overwriting the first error with another error (regression from v0.18.3)
  - trim whitespace in error message
  - fix measurement of error message
&nbsp;

- fix: detect circular refs in bridge messages
  - also, stringify invalid messages for easier debugging
&nbsp;

- fix: catch invalid native calls from JS
  - This allows RCTRedBox to show when JS tries to send an invalid native call over the bridge. Without this commit, you need to check the Xcode logs to know what happened.
&nbsp;

- fix: re-enable redBox in _RCTLogNativeInternal
  - This commented-out line was preventing RCTRedBox from appearing for certain errors (eg: failed to load bundle)
&nbsp;

- fix: "Failed to load bundle" error 
  - Improved readability by adding in some line breaks
&nbsp;

- fix: filter out stack frames with no filename
  - These stack frames show up as empty cells in the table view, so just remove them. I checked all references to `_lastStackTrace` to make sure I didn't break anything.
&nbsp;

- fix: ensure native stack frame has an absolute file path

- fix: avoid calling deselectRow with -1