### PR TITLE
Various fixes to RCTView props

### DIFF
--- a/React/Views/NSView+React.h
+++ b/React/Views/NSView+React.h
@@ -114,4 +114,7 @@
  */
 @property (nonatomic, assign) BOOL clipsToBounds;
 
+/** Populate the `layer` ivar when nil */
+- (void)ensureLayerExists;
+
 @end

--- a/React/Views/NSView+React.h
+++ b/React/Views/NSView+React.h
@@ -113,6 +113,7 @@
  * UIKit replacement
  */
 @property (nonatomic, assign) BOOL clipsToBounds;
+@property (nonatomic, assign) CATransform3D transform;
 
 /** Populate the `layer` ivar when nil */
 - (void)ensureLayerExists;

--- a/React/Views/NSView+React.m
+++ b/React/Views/NSView+React.m
@@ -305,4 +305,16 @@ static inline CGRect NSEdgeInsetsInsetRect(CGRect rect, NSEdgeInsets insets) {
   }
 }
 
+- (CATransform3D)transform
+{
+  return CATransform3DIdentity;
+}
+
+- (void)setTransform:(__unused CATransform3D)transform
+{
+  // Do nothing by default.
+  // Native views must synthesize their own "transform" property,
+  // override "displayLayer:", and apply the transform there.
+}
+
 @end

--- a/React/Views/NSView+React.m
+++ b/React/Views/NSView+React.m
@@ -295,4 +295,18 @@ static inline CGRect NSEdgeInsetsInsetRect(CGRect rect, NSEdgeInsets insets) {
   return self;
 }
 
+#pragma mark - Other
+
+- (void)ensureLayerExists
+{
+  if (!self.layer) {
+    // Set `wantsLayer` first to create a "layer-backed view" instead of a "layer-hosting view".
+    self.wantsLayer = YES;
+
+    CALayer *layer = [CALayer layer];
+    layer.delegate = (id<CALayerDelegate>)self;
+    self.layer = layer;
+  }
+}
+
 @end

--- a/React/Views/NSView+React.m
+++ b/React/Views/NSView+React.m
@@ -300,12 +300,8 @@ static inline CGRect NSEdgeInsetsInsetRect(CGRect rect, NSEdgeInsets insets) {
 - (void)ensureLayerExists
 {
   if (!self.layer) {
-    // Set `wantsLayer` first to create a "layer-backed view" instead of a "layer-hosting view".
     self.wantsLayer = YES;
-
-    CALayer *layer = [CALayer layer];
-    layer.delegate = (id<CALayerDelegate>)self;
-    self.layer = layer;
+    self.layer.delegate = (id<CALayerDelegate>)self;
   }
 }
 

--- a/React/Views/NSView+React.m
+++ b/React/Views/NSView+React.m
@@ -175,10 +175,10 @@
     return;
   }
 
+  [self ensureLayerExists];
   self.frame = frame;
-  
-  // TODO: why position matters? It's only produce bugs
-  // OSX requires position and anchor point to rotate from center
+
+  // Ensure the anchorPoint is in the center.
   self.layer.position = position;
   self.layer.bounds = bounds;
   self.layer.anchorPoint = anchor;

--- a/React/Views/RCTView.h
+++ b/React/Views/RCTView.h
@@ -113,11 +113,7 @@
 @property (nonatomic, assign) CGFloat borderEndWidth;
 @property (nonatomic, assign) CGFloat borderWidth;
 
-/**
- * Initial tranformation for a view which is not rendered yet
- */
 @property (nonatomic, assign) CATransform3D transform;
-@property (nonatomic, assign) bool shouldBeTransformed;
 
 @property (nonatomic, copy) RCTDirectEventBlock onDragEnter;
 @property (nonatomic, copy) RCTDirectEventBlock onDragLeave;

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -124,6 +124,7 @@ static NSString *RCTRecursiveAccessibilityLabel(NSView *view)
     _borderBottomStartRadius = -1;
     _borderBottomEndRadius = -1;
     _borderStyle = RCTBorderStyleSolid;
+    _transform = CATransform3DIdentity;
     self.clipsToBounds = NO;
   }
 
@@ -192,6 +193,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
 - (void)setTransform:(CATransform3D)transform
 {
   _transform = transform;
+  [self setNeedsDisplay:YES];
 }
 
 - (NSView *)hitTest:(CGPoint)point
@@ -578,11 +580,12 @@ static CGFloat RCTDefaultIfNegativeTo(CGFloat defaultValue, CGFloat x) {
 
 - (void)displayLayer:(CALayer *)layer
 {
-  if (self.shouldBeTransformed) {
-    self.layer.transform = self.transform;
-    self.shouldBeTransformed = NO;
+  if (!CATransform3DEqualToTransform(_transform, layer.transform)) {
+    layer.transform = _transform;
+    // Enable edge antialiasing in perspective transforms
+    layer.edgeAntialiasingMask = !(_transform.m34 == 0.0f);
   }
-  
+
   if (CGSizeEqualToSize(layer.bounds.size, CGSizeZero)) {
     return;
   }

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -586,6 +586,10 @@ static CGFloat RCTDefaultIfNegativeTo(CGFloat defaultValue, CGFloat x) {
     layer.edgeAntialiasingMask = !(_transform.m34 == 0.0f);
   }
 
+  // Ensure the anchorPoint is in the center.
+  layer.position = (CGPoint){CGRectGetMidX(self.frame), CGRectGetMidY(self.frame)};
+  layer.anchorPoint = (CGPoint){0.5, 0.5};
+
   if (CGSizeEqualToSize(layer.bounds.size, CGSizeZero)) {
     return;
   }

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -576,18 +576,6 @@ static CGFloat RCTDefaultIfNegativeTo(CGFloat defaultValue, CGFloat x) {
   }
 }
 
-- (void)ensureLayerExists
-{
-  if (!self.layer) {
-    // Set `wantsLayer` first to create a "layer-backed view" instead of a "layer-hosting view".
-    self.wantsLayer = YES;
-
-    CALayer *layer = [CALayer layer];
-    layer.delegate = self;
-    self.layer = layer;
-  }
-}
-
 - (void)displayLayer:(CALayer *)layer
 {
   if (self.shouldBeTransformed) {

--- a/React/Views/RCTViewManager.h
+++ b/React/Views/RCTViewManager.h
@@ -119,4 +119,24 @@ RCT_REMAP_VIEW_PROPERTY(name, __custom__, type)         \
 RCT_REMAP_SHADOW_PROPERTY(name, __custom__, type)         \
 - (void)set_##name:(id)json forShadowView:(viewClass *)view
 
+/**
+ * This macro maps a named property to an arbitrary key path in the view's layer.
+ */
+#define RCT_REMAP_LAYER_PROPERTY(name, keyPath, type) \
+RCT_CUSTOM_VIEW_PROPERTY(name, type, RCTView)         \
+{                                                     \
+  if (json) {                                         \
+    [view ensureLayerExists];                         \
+    view.layer.keyPath = [RCTConvert type:json];      \
+  } else {                                            \
+    view.layer.keyPath = defaultView.layer.keyPath;   \
+  }                                                   \
+}
+
+/**
+ * This handles the simple case, where JS and native property names match.
+ */
+#define RCT_EXPORT_LAYER_PROPERTY(name, type) \
+RCT_REMAP_LAYER_PROPERTY(name, name, type)
+
 @end

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -88,16 +88,6 @@ RCT_EXPORT_MODULE()
   return nil;
 }
 
-- (void)checkLayerExists:(NSView *)view
-{
-  if (!view.layer) {
-    [view setWantsLayer:YES];
-    CALayer *viewLayer = [CALayer layer];
-    viewLayer.delegate = (id<CALayerDelegate>)view;
-    [view setLayer:viewLayer];
-  }
-}
-
 #pragma mark - View properties
 
 #if TARGET_OS_TV
@@ -168,7 +158,7 @@ RCT_CUSTOM_VIEW_PROPERTY(draggedTypes, NSArray*<NSString *>, RCTView)
 RCT_CUSTOM_VIEW_PROPERTY(opacity, float, RCTView)
 {
     if (json) {
-        [self checkLayerExists:view];
+        [view ensureLayerExists];
         [view.layer setOpacity:[RCTConvert float:json]];
     } else {
         [view.layer setOpacity:1];
@@ -193,7 +183,7 @@ RCT_CUSTOM_VIEW_PROPERTY(removeClippedSubviews, BOOL, RCTView)
 }
 RCT_CUSTOM_VIEW_PROPERTY(borderRadius, CGFloat, RCTView) {
   if ([view respondsToSelector:@selector(setBorderRadius:)]) {
-    [self checkLayerExists:view];
+    [view ensureLayerExists];
     view.borderRadius = json ? [RCTConvert CGFloat:json] : defaultView.borderRadius;
   } else {
     view.layer.cornerRadius = json ? [RCTConvert CGFloat:json] : defaultView.layer.cornerRadius;
@@ -202,7 +192,7 @@ RCT_CUSTOM_VIEW_PROPERTY(borderRadius, CGFloat, RCTView) {
 RCT_CUSTOM_VIEW_PROPERTY(borderColor, CGColor, RCTView)
 {
   if ([view respondsToSelector:@selector(setBorderColor:)]) {
-    [self checkLayerExists:view];
+    [view ensureLayerExists];
     view.borderColor = json ? [RCTConvert CGColor:json] : defaultView.borderColor;
   } else {
     view.layer.borderColor = json ? [RCTConvert CGColor:json] : defaultView.layer.borderColor;
@@ -211,7 +201,7 @@ RCT_CUSTOM_VIEW_PROPERTY(borderColor, CGColor, RCTView)
 RCT_CUSTOM_VIEW_PROPERTY(borderWidth, float, RCTView)
 {
   if ([view respondsToSelector:@selector(setBorderWidth:)]) {
-    [self checkLayerExists:view];
+    [view ensureLayerExists];
     view.borderWidth = json ? [RCTConvert CGFloat:json] : defaultView.borderWidth;
   } else {
     view.layer.borderWidth = json ? [RCTConvert CGFloat:json] : defaultView.layer.borderWidth;
@@ -262,14 +252,14 @@ RCT_CUSTOM_VIEW_PROPERTY(contextMenu, NSArray*<NSDictionary *>, __unused RCTView
 RCT_CUSTOM_VIEW_PROPERTY(border##SIDE##Width, float, RCTView)           \
 {                                                                       \
   if ([view respondsToSelector:@selector(setBorder##SIDE##Width:)]) {   \
-    [self checkLayerExists:view];                                       \
+    [view ensureLayerExists];                                           \
     view.border##SIDE##Width = json ? [RCTConvert CGFloat:json] : defaultView.border##SIDE##Width; \
   }                                                                     \
 }                                                                       \
 RCT_CUSTOM_VIEW_PROPERTY(border##SIDE##Color, NSColor, RCTView)         \
 {                                                                       \
   if ([view respondsToSelector:@selector(setBorder##SIDE##Color:)]) {   \
-    [self checkLayerExists:view];                                       \
+    [view ensureLayerExists];                                           \
     view.border##SIDE##Color = json ? [RCTConvert CGColor:json] : defaultView.border##SIDE##Color; \
   }                                                                     \
 }

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -111,11 +111,12 @@ RCT_EXPORT_VIEW_PROPERTY(nativeID, NSString)
 RCT_REMAP_VIEW_PROPERTY(testID, reactAccessibilityElement.accessibilityIdentifier, NSString)
 
 RCT_EXPORT_VIEW_PROPERTY(backgroundColor, NSColor)
-RCT_REMAP_VIEW_PROPERTY(backfaceVisibility, layer.doubleSided, css_backface_visibility_t)
-RCT_REMAP_VIEW_PROPERTY(shadowColor, layer.shadowColor, CGColor)
-RCT_REMAP_VIEW_PROPERTY(shadowOffset, layer.shadowOffset, CGSize)
-RCT_REMAP_VIEW_PROPERTY(shadowOpacity, layer.shadowOpacity, float)
-RCT_REMAP_VIEW_PROPERTY(shadowRadius, layer.shadowRadius, CGFloat)
+RCT_REMAP_LAYER_PROPERTY(backfaceVisibility, doubleSided, css_backface_visibility_t)
+RCT_EXPORT_LAYER_PROPERTY(opacity, float)
+RCT_EXPORT_LAYER_PROPERTY(shadowColor, CGColor)
+RCT_EXPORT_LAYER_PROPERTY(shadowOffset, CGSize)
+RCT_EXPORT_LAYER_PROPERTY(shadowOpacity, float)
+RCT_EXPORT_LAYER_PROPERTY(shadowRadius, CGFloat)
 RCT_REMAP_VIEW_PROPERTY(toolTip, toolTip, NSString)
 RCT_CUSTOM_VIEW_PROPERTY(overflow, YGOverflow, RCTView)
 {
@@ -142,18 +143,6 @@ RCT_CUSTOM_VIEW_PROPERTY(draggedTypes, NSArray*<NSString *>, RCTView)
         [view registerForDraggedTypes:defaultView.registeredDraggedTypes];
     }
 }
-
-RCT_CUSTOM_VIEW_PROPERTY(opacity, float, RCTView)
-{
-    if (json) {
-        [view ensureLayerExists];
-        [view.layer setOpacity:[RCTConvert float:json]];
-    } else {
-        [view.layer setOpacity:1];
-    }
-}
-
-
 RCT_CUSTOM_VIEW_PROPERTY(pointerEvents, RCTPointerEvents, RCTView)
 {
   if ([view respondsToSelector:@selector(setPointerEvents:)]) {

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -141,8 +141,8 @@ RCT_CUSTOM_VIEW_PROPERTY(transform, CATransform3D, RCTView)
     view.layer.transform = transform;
   }
 
-  // TODO: Improve this by enabling edge antialiasing only for transforms with rotation or skewing
-  view.layer.edgeAntialiasingMask = !CATransform3DIsIdentity(transform);
+  // Enable edge antialiasing in perspective transforms
+  view.layer.edgeAntialiasingMask = !(transform.m34 == 0.0f);
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(draggedTypes, NSArray*<NSString *>, RCTView)

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -131,19 +131,7 @@ RCT_CUSTOM_VIEW_PROPERTY(shouldRasterizeIOS, BOOL, RCTView)
   view.layer.rasterizationScale = view.layer.shouldRasterize ? [NSScreen mainScreen].backingScaleFactor : defaultView.layer.rasterizationScale;
 }
 
-RCT_CUSTOM_VIEW_PROPERTY(transform, CATransform3D, RCTView)
-{
-  CATransform3D transform = json ? [RCTConvert CATransform3D:json] : defaultView.layer.transform;
-  if ([view respondsToSelector:@selector(shouldBeTransformed)] && !view.superview) {
-    view.shouldBeTransformed = YES;
-    view.transform = transform;
-  } else {
-    view.layer.transform = transform;
-  }
-
-  // Enable edge antialiasing in perspective transforms
-  view.layer.edgeAntialiasingMask = !(transform.m34 == 0.0f);
-}
+RCT_EXPORT_VIEW_PROPERTY(transform, CATransform3D)
 
 RCT_CUSTOM_VIEW_PROPERTY(draggedTypes, NSArray*<NSString *>, RCTView)
 {

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -128,6 +128,9 @@ RCT_CUSTOM_VIEW_PROPERTY(overflow, YGOverflow, RCTView)
 }
 RCT_CUSTOM_VIEW_PROPERTY(shouldRasterizeIOS, BOOL, RCTView)
 {
+  if (json) {
+    [view ensureLayerExists];
+  }
   view.layer.shouldRasterize = json ? [RCTConvert BOOL:json] : defaultView.layer.shouldRasterize;
   view.layer.rasterizationScale = view.layer.shouldRasterize ? [NSScreen mainScreen].backingScaleFactor : defaultView.layer.rasterizationScale;
 }
@@ -150,17 +153,18 @@ RCT_CUSTOM_VIEW_PROPERTY(pointerEvents, RCTPointerEvents, RCTView)
     return;
   }
 }
-
-
 RCT_CUSTOM_VIEW_PROPERTY(removeClippedSubviews, BOOL, RCTView)
 {
   if ([view respondsToSelector:@selector(setRemoveClippedSubviews:)]) {
     view.removeClippedSubviews = json ? [RCTConvert BOOL:json] : defaultView.removeClippedSubviews;
   }
 }
-RCT_CUSTOM_VIEW_PROPERTY(borderRadius, CGFloat, RCTView) {
-  if ([view respondsToSelector:@selector(setBorderRadius:)]) {
+RCT_CUSTOM_VIEW_PROPERTY(borderRadius, CGFloat, RCTView)
+{
+  if (json) {
     [view ensureLayerExists];
+  }
+  if ([view respondsToSelector:@selector(setBorderRadius:)]) {
     view.borderRadius = json ? [RCTConvert CGFloat:json] : defaultView.borderRadius;
   } else {
     view.layer.cornerRadius = json ? [RCTConvert CGFloat:json] : defaultView.layer.cornerRadius;
@@ -168,8 +172,10 @@ RCT_CUSTOM_VIEW_PROPERTY(borderRadius, CGFloat, RCTView) {
 }
 RCT_CUSTOM_VIEW_PROPERTY(borderColor, CGColor, RCTView)
 {
-  if ([view respondsToSelector:@selector(setBorderColor:)]) {
+  if (json) {
     [view ensureLayerExists];
+  }
+  if ([view respondsToSelector:@selector(setBorderColor:)]) {
     view.borderColor = json ? [RCTConvert CGColor:json] : defaultView.borderColor;
   } else {
     view.layer.borderColor = json ? [RCTConvert CGColor:json] : defaultView.layer.borderColor;
@@ -177,8 +183,10 @@ RCT_CUSTOM_VIEW_PROPERTY(borderColor, CGColor, RCTView)
 }
 RCT_CUSTOM_VIEW_PROPERTY(borderWidth, float, RCTView)
 {
-  if ([view respondsToSelector:@selector(setBorderWidth:)]) {
+  if (json) {
     [view ensureLayerExists];
+  }
+  if ([view respondsToSelector:@selector(setBorderWidth:)]) {
     view.borderWidth = json ? [RCTConvert CGFloat:json] : defaultView.borderWidth;
   } else {
     view.layer.borderWidth = json ? [RCTConvert CGFloat:json] : defaultView.layer.borderWidth;
@@ -186,6 +194,9 @@ RCT_CUSTOM_VIEW_PROPERTY(borderWidth, float, RCTView)
 }
 RCT_CUSTOM_VIEW_PROPERTY(borderStyle, RCTBorderStyle, RCTView)
 {
+  if (json) {
+    [view ensureLayerExists];
+  }
   if ([view respondsToSelector:@selector(setBorderStyle:)]) {
     view.borderStyle = json ? [RCTConvert RCTBorderStyle:json] : defaultView.borderStyle;
   }


### PR DESCRIPTION
- move `[RCTViewManager checkLayerExists:]` to `[NSView ensureLayerExists]`
- enable edge antialiasing only for transforms with perspective
- stop setting `layer` manually in `[NSView ensureLayerExists]` (let the `layer` getter call `[NSView makeBackingLayer]` instead)
- never set `layer.transform` directly except in `[RCTView displayLayer:]`
- call `ensureLayerExists` before setting any layer-related prop
- call `ensureLayerExists` inside `reactSetFrame:` so layer props can be set
- enforce `position` and `anchorPoint` by setting them in `[RCTView displayLayer:]`