### PR TITLE
Fix for bug where mouse coordinates are wrong

### DIFF
--- a/React/Base/RCTTouchHandler.m
+++ b/React/Base/RCTTouchHandler.m
@@ -106,10 +106,13 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithTarget:(id)target action:(SEL)action
 
     NSPoint touchLocation = [touch locationInWindow];
 
-    // adjust touchLocation if our view placed inside custom PopoverWindow
     if ([[self.view window].className isEqualToString:@"_NSPopoverWindow"]) {
+      // adjust touchLocation if our view placed inside custom PopoverWindow
       NSPoint rootOrigin = [self.view window].contentView.frame.origin;
       touchLocation = NSMakePoint(touchLocation.x - rootOrigin.x, touchLocation.y - rootOrigin.y);
+    } else if (self.view.superview) {
+      // if our view has a superview, adjust the window coordinates to view coordinates.
+      touchLocation = [touch.window.contentView convertPoint:touchLocation toView:self.view.superview];
     }
 
     // TODO: get rid of explicit comparison


### PR DESCRIPTION
This occurs when our main react view is not the contentView of a
window.  Touch coordinates are in window coordinates, but `hitTest`
expects coordinates in the coordinate system of our superview.

This is my first PR, let me know what I can do to get this in.